### PR TITLE
Optimize SQLite performance and fix auto-vacuum initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ some query behavior changes (see Breaking changes).
 
 ### Performance
 
+- **`PRAGMA optimize` on disconnect.** `Disconnect`/`DisconnectAsync`/`Dispose` now run
+  SQLite's recommended `PRAGMA optimize` (bounded by `analysis_limit = 400`) so the
+  query planner keeps fresh statistics and continues to choose indexes — including
+  expression indexes over `JSON_EXTRACT`.
+- **Bounded WAL on mobile.** The `Mobile` profile sets `journal_size_limit = 8 MB` so
+  the WAL file truncates after a checkpoint instead of growing unbounded; `Desktop`
+  leaves it unlimited.
+- **`Cleanup` truncates the WAL.** `Cleanup(vacuum: true)` now runs
+  `wal_checkpoint(TRUNCATE)` after reclaiming free space, returning the WAL file's space
+  to disk as well.
 - **Device-aware SQLite tuning.** A new `TychoPerformanceProfile` (`Mobile` /
   `Desktop`) constructor parameter selects a preset of PRAGMA tuning, with optional
   `cacheSizeKb` / `mmapSizeBytes` overrides. `Mobile` (the default) uses a small page

--- a/TychoDB.UnitTests/ConfigurationTests.cs
+++ b/TychoDB.UnitTests/ConfigurationTests.cs
@@ -42,6 +42,87 @@ public class ConfigurationTests
     }
 
     [TestMethod]
+    public void AutoVacuum_IsSetBeforeJournalMode()
+    {
+        // Regression guard: switching to WAL writes the DB header and locks the
+        // auto_vacuum mode, so auto_vacuum must precede journal_mode = WAL or new
+        // databases are silently created with auto_vacuum = NONE.
+        var script = Queries.BuildConnectionScript(TychoPerformanceProfile.Mobile);
+
+        var autoVacuumIndex = script.IndexOf("PRAGMA auto_vacuum", StringComparison.Ordinal);
+        var journalModeIndex = script.IndexOf("PRAGMA journal_mode", StringComparison.Ordinal);
+
+        autoVacuumIndex.ShouldBeGreaterThanOrEqualTo(0);
+        journalModeIndex.ShouldBeGreaterThanOrEqualTo(0);
+        autoVacuumIndex.ShouldBeLessThan(journalModeIndex, "auto_vacuum must be set before journal_mode = WAL");
+    }
+
+    [TestMethod]
+    public async Task FreshDatabase_IsCreatedWithIncrementalAutoVacuum()
+    {
+        var path = System.IO.Path.GetTempPath();
+        var name = $"{Guid.NewGuid()}.db";
+
+        using (var db = new Tycho(path, GetSerializer(), dbName: name, rebuildCache: true, requireTypeRegistration: false, useConnectionPooling: false))
+        {
+            await db.ConnectAsync();
+            await db.WriteObjectAsync(new TestClassA { StringProperty = "k", IntProperty = 1 }, x => x.StringProperty);
+        }
+
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+
+        // 2 == incremental. Verified on a separate connection after the exclusive one closes.
+        ReadAutoVacuumMode(System.IO.Path.Combine(path, name)).ShouldBe(2);
+    }
+
+    [TestMethod]
+    public async Task Cleanup_MigratesLegacyNoneDatabase_AndReclaimsSpace()
+    {
+        var path = System.IO.Path.GetTempPath();
+        var name = $"{Guid.NewGuid()}.db";
+        var fullPath = System.IO.Path.Combine(path, name);
+
+        // Pre-create a legacy NONE database (journal_mode set before auto_vacuum).
+        using (var raw = new Microsoft.Data.Sqlite.SqliteConnection($"Filename={fullPath};Pooling=False"))
+        {
+            raw.Open();
+            using var cmd = raw.CreateCommand();
+            cmd.CommandText = "PRAGMA journal_mode = WAL; CREATE TABLE _legacy(x);";
+            cmd.ExecuteNonQuery();
+        }
+
+        ReadAutoVacuumMode(fullPath).ShouldBe(0, "precondition: legacy DB is NONE");
+
+        using (var db = new Tycho(path, GetSerializer(), dbName: name, rebuildCache: false, requireTypeRegistration: false, useConnectionPooling: false))
+        {
+            await db.ConnectAsync();
+
+            // Create bloat: write many objects, then delete them (free pages).
+            var many = Enumerable.Range(0, 500)
+                .Select(i => new TestClassA { StringProperty = $"k{i}", IntProperty = i })
+                .ToList();
+            await db.WriteObjectsAsync(many, x => x.StringProperty);
+
+            await db.DeleteObjectsAsync<TestClassA>();
+
+            // incremental_vacuum would be a no-op here; Cleanup must detect NONE and
+            // run a full VACUUM to reclaim space and convert to incremental.
+            db.Cleanup(shrinkMemory: true, vacuum: true);
+        }
+
+        ReadAutoVacuumMode(fullPath).ShouldBe(2, "Cleanup should convert the DB to incremental auto-vacuum");
+    }
+
+    private static long ReadAutoVacuumMode(string dbFullPath)
+    {
+        using var conn = new Microsoft.Data.Sqlite.SqliteConnection($"Filename={dbFullPath};Pooling=False");
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "PRAGMA auto_vacuum;";
+        return cmd.ExecuteScalar() is long v ? v : -1;
+    }
+
+    [TestMethod]
     public void Overrides_TakePrecedenceOverProfile()
     {
         var script = Queries.BuildConnectionScript(

--- a/TychoDB.UnitTests/ConfigurationTests.cs
+++ b/TychoDB.UnitTests/ConfigurationTests.cs
@@ -21,6 +21,7 @@ public class ConfigurationTests
         script.ShouldContain("PRAGMA cache_size = -8000;");
         script.ShouldContain("PRAGMA mmap_size = 33554432;");
         script.ShouldContain("PRAGMA wal_autocheckpoint = 512;");
+        script.ShouldContain("PRAGMA journal_size_limit = 8388608;");
 
         // Shared PRAGMAs still present.
         script.ShouldContain("PRAGMA journal_mode = WAL;");
@@ -39,6 +40,7 @@ public class ConfigurationTests
         script.ShouldContain("PRAGMA cache_size = -65536;");
         script.ShouldContain("PRAGMA mmap_size = 268435456;");
         script.ShouldContain("PRAGMA wal_autocheckpoint = 2000;");
+        script.ShouldContain("PRAGMA journal_size_limit = -1;");
     }
 
     [TestMethod]

--- a/TychoDB/Queries.cs
+++ b/TychoDB/Queries.cs
@@ -70,6 +70,11 @@ internal static class Queries
     private const long MobileMmapSizeBytes = 33_554_432; // 32 MB memory-map
     private const int MobileWalAutocheckpoint = 512;     // small WAL
 
+    // Cap the WAL file on mobile so it truncates back to this size after a
+    // checkpoint instead of growing unbounded; -1 leaves it unlimited (desktop).
+    private const long MobileJournalSizeLimitBytes = 8_388_608; // 8 MB
+    private const long DesktopJournalSizeLimitBytes = -1;       // unlimited
+
     private const int DesktopCacheSizeKb = 65_536;        // 64 MB page cache
     private const long DesktopMmapSizeBytes = 268_435_456; // 256 MB memory-map
     private const int DesktopWalAutocheckpoint = 2_000;
@@ -88,14 +93,16 @@ internal static class Queries
         int cacheSizeKb = cacheSizeKbOverride ?? (desktop ? DesktopCacheSizeKb : MobileCacheSizeKb);
         long mmapSizeBytes = mmapSizeBytesOverride ?? (desktop ? DesktopMmapSizeBytes : MobileMmapSizeBytes);
         int walAutocheckpoint = desktop ? DesktopWalAutocheckpoint : MobileWalAutocheckpoint;
+        long journalSizeLimit = desktop ? DesktopJournalSizeLimitBytes : MobileJournalSizeLimitBytes;
 
-        var sb = new System.Text.StringBuilder(SharedPragmas.Length + SchemaDdl.Length + 128);
+        var sb = new System.Text.StringBuilder(SharedPragmas.Length + SchemaDdl.Length + 160);
         var ic = System.Globalization.CultureInfo.InvariantCulture;
 
         sb.Append(SharedPragmas).Append('\n')
           .Append("PRAGMA cache_size = -").Append(cacheSizeKb.ToString(ic)).Append(";\n")
           .Append("PRAGMA mmap_size = ").Append(mmapSizeBytes.ToString(ic)).Append(";\n")
-          .Append("PRAGMA wal_autocheckpoint = ").Append(walAutocheckpoint.ToString(ic)).Append(";\n\n")
+          .Append("PRAGMA wal_autocheckpoint = ").Append(walAutocheckpoint.ToString(ic)).Append(";\n")
+          .Append("PRAGMA journal_size_limit = ").Append(journalSizeLimit.ToString(ic)).Append(";\n\n")
           .Append(SchemaDdl);
 
         return sb.ToString();

--- a/TychoDB/Queries.cs
+++ b/TychoDB/Queries.cs
@@ -12,16 +12,20 @@ internal static class Queries
     // PRAGMAs shared by every profile. These are single-user / single-connection
     // choices: WAL journaling with EXCLUSIVE locking (one persistent connection),
     // NORMAL synchronous (safe under WAL), in-memory temp store, and incremental
-    // auto-vacuum. auto_vacuum only takes effect when the database is first created,
-    // so it must precede the table DDL.
+    // auto-vacuum.
+    //
+    // auto_vacuum MUST be the first statement: it can only be applied when the
+    // database is first created, and switching to WAL writes the database header —
+    // so if auto_vacuum is set after journal_mode = WAL it silently stays at the
+    // default (NONE) even on a brand-new file, leaving incremental_vacuum a no-op.
     private const string SharedPragmas =
         """
+        PRAGMA auto_vacuum = INCREMENTAL;
         PRAGMA journal_mode = WAL;
         PRAGMA locking_mode = EXCLUSIVE;
         PRAGMA synchronous = NORMAL;
         PRAGMA temp_store = MEMORY;
         PRAGMA busy_timeout = 5000;
-        PRAGMA auto_vacuum = INCREMENTAL;
         """;
 
     // Table + index DDL. Idempotent (IF NOT EXISTS); runs on every connect.

--- a/TychoDB/Tycho.cs
+++ b/TychoDB/Tycho.cs
@@ -1903,8 +1903,15 @@ public class Tycho : IDisposable
     /// <summary>
     /// Performs database cleanup operations to optimize performance and reduce size.
     /// </summary>
-    /// <param name="shrinkMemory">Whether to shrink the database's memory usage.</param>
-    /// <param name="vacuum">Whether to perform an incremental vacuum operation.</param>
+    /// <param name="shrinkMemory">Whether to release heap memory held by SQLite.</param>
+    /// <param name="vacuum">
+    /// Whether to reclaim free space to disk. On a database already in incremental
+    /// auto-vacuum mode this runs a cheap in-place <c>incremental_vacuum</c>. On a
+    /// legacy database that was created without incremental auto-vacuum (e.g. by an
+    /// older version, or before the auto_vacuum ordering fix), <c>incremental_vacuum</c>
+    /// is a no-op, so this instead runs a one-time full <c>VACUUM</c> that both reclaims
+    /// the space and converts the database to incremental auto-vacuum for the future.
+    /// </param>
     public void Cleanup(bool shrinkMemory = true, bool vacuum = false)
     {
         ArgumentNullException.ThrowIfNull(_connection);
@@ -1917,29 +1924,50 @@ public class Tycho : IDisposable
                 {
                     try
                     {
-                        using var createIndexCommand = conn.CreateCommand();
-
-                        string? command = null;
-
                         if (state.shrinkMemory)
                         {
-                            command += "PRAGMA shrink_memory; ";
+                            using var shrinkCommand = conn.CreateCommand();
+                            shrinkCommand.CommandText = "PRAGMA shrink_memory;";
+                            shrinkCommand.ExecuteNonQuery();
                         }
 
-                        if (state.vacuum)
+                        if (!state.vacuum)
                         {
-                            command += "PRAGMA incremental_vacuum; ";
+                            return;
                         }
 
-#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
-                        createIndexCommand.CommandText = command;
-#pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
+                        // incremental_vacuum only reclaims space when the database is in
+                        // INCREMENTAL (2) auto-vacuum mode.
+                        long autoVacuumMode;
+                        using (var modeCommand = conn.CreateCommand())
+                        {
+                            modeCommand.CommandText = "PRAGMA auto_vacuum;";
+                            autoVacuumMode = modeCommand.ExecuteScalar() is long mode ? mode : 0L;
+                        }
 
-                        createIndexCommand.ExecuteNonQuery();
+                        using var vacuumCommand = conn.CreateCommand();
+
+                        if (autoVacuumMode == 2)
+                        {
+                            vacuumCommand.CommandText = "PRAGMA incremental_vacuum;";
+                        }
+                        else
+                        {
+                            // Legacy/NONE database: a full VACUUM reclaims free space and
+                            // converts to incremental auto-vacuum. Use a file-backed temp
+                            // store for the rebuild so a large database does not spike
+                            // memory (VACUUM would otherwise honor temp_store = MEMORY and
+                            // build the whole copy in RAM), then restore the in-memory
+                            // temp store for normal operation.
+                            vacuumCommand.CommandText =
+                                "PRAGMA temp_store = FILE; PRAGMA auto_vacuum = INCREMENTAL; VACUUM; PRAGMA temp_store = MEMORY;";
+                        }
+
+                        vacuumCommand.ExecuteNonQuery();
                     }
                     catch (Exception ex)
                     {
-                        throw new TychoException($"Failed to shrink memory", ex);
+                        throw new TychoException("Failed to clean up database", ex);
                     }
                 },
                 _persistConnection);

--- a/TychoDB/Tycho.cs
+++ b/TychoDB/Tycho.cs
@@ -236,9 +236,13 @@ public class Tycho : IDisposable
     {
         lock (_connectionLock)
         {
-            _connection?.Close();
-            _connection?.Dispose();
-            _connection = null;
+            if (_connection is not null)
+            {
+                RunOptimize(_connection);
+                _connection.Close();
+                _connection.Dispose();
+                _connection = null;
+            }
         }
     }
 
@@ -253,10 +257,32 @@ public class Tycho : IDisposable
             return;
         }
 
+        RunOptimize(_connection);
+
         await _connection.CloseAsync().ConfigureAwait(false);
         await _connection.DisposeAsync().ConfigureAwait(false);
 
         _connection = null;
+    }
+
+    /// <summary>
+    /// Runs SQLite's recommended <c>PRAGMA optimize</c> (bounded by
+    /// <c>analysis_limit</c>) before closing a connection, refreshing query-planner
+    /// statistics so indexes — including expression indexes over JSON_EXTRACT — keep
+    /// being chosen. Best-effort: failures never block teardown.
+    /// </summary>
+    private static void RunOptimize(SqliteConnection connection)
+    {
+        try
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText = "PRAGMA analysis_limit = 400; PRAGMA optimize;";
+            command.ExecuteNonQuery();
+        }
+        catch
+        {
+            // Advisory only — ignore failures during teardown.
+        }
     }
 
     public void Backup(SqliteConnection backupDatabaseConnection)
@@ -1949,7 +1975,10 @@ public class Tycho : IDisposable
 
                         if (autoVacuumMode == 2)
                         {
-                            vacuumCommand.CommandText = "PRAGMA incremental_vacuum;";
+                            // In-place free-page reclamation, then truncate the WAL file so
+                            // its space is returned to disk too.
+                            vacuumCommand.CommandText =
+                                "PRAGMA incremental_vacuum; PRAGMA wal_checkpoint(TRUNCATE);";
                         }
                         else
                         {
@@ -1958,9 +1987,9 @@ public class Tycho : IDisposable
                             // store for the rebuild so a large database does not spike
                             // memory (VACUUM would otherwise honor temp_store = MEMORY and
                             // build the whole copy in RAM), then restore the in-memory
-                            // temp store for normal operation.
+                            // temp store for normal operation and truncate the WAL.
                             vacuumCommand.CommandText =
-                                "PRAGMA temp_store = FILE; PRAGMA auto_vacuum = INCREMENTAL; VACUUM; PRAGMA temp_store = MEMORY;";
+                                "PRAGMA temp_store = FILE; PRAGMA auto_vacuum = INCREMENTAL; VACUUM; PRAGMA temp_store = MEMORY; PRAGMA wal_checkpoint(TRUNCATE);";
                         }
 
                         vacuumCommand.ExecuteNonQuery();
@@ -2074,6 +2103,11 @@ public class Tycho : IDisposable
 
         if (disposing)
         {
+            if (_connection is not null)
+            {
+                RunOptimize(_connection);
+            }
+
             _commandBuilder.Dispose();
             _connectionGate?.Dispose();
             _connection?.Close();


### PR DESCRIPTION
### Summary
Ensures `PRAGMA auto_vacuum` is set before WAL mode to correctly enable incremental vacuuming and implements `PRAGMA optimize` on connection teardown for better query planning. 

### Changes
- Reorders PRAGMA statements to fix a bug where new databases were silently created without auto-vacuum support.
- Configures a bounded WAL file size for mobile profiles and enables WAL truncation during cleanup to reclaim disk space.
- Enhances the `Cleanup` method to detect legacy databases and perform a one-time full vacuum to migrate them to incremental mode.

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules