### PR TITLE
fix(sql): stop clearing the shared command builder outside the connection gate

### DIFF
--- a/TychoDB.UnitTests/TychoDbTests.cs
+++ b/TychoDB.UnitTests/TychoDbTests.cs
@@ -2265,6 +2265,71 @@ public class TychoDbTests
         recorder.Reports.Last().ShouldBe(1.0);
     }
 
+    /// <summary>
+    /// Overlapping operations issued from the same thread used to share one command
+    /// <see cref="System.Text.StringBuilder"/>, because the builder was taken from a
+    /// <see cref="System.Threading.ThreadLocal{T}"/> (and cleared) on the calling thread, then
+    /// written to after the connection gate was awaited, on a pool thread. A later operation's
+    /// clear could truncate an earlier one's SQL mid-build, which SQLite rejected with errors
+    /// such as near "JSON_EXTRACT", or corrupt the builder's chunk chain badly enough to spin
+    /// forever. The timeout is load-bearing: the original defect hangs rather than throws, and
+    /// without it a regression wedges the run instead of failing it.
+    /// <para>
+    /// The builder is now shared per database and is safe only because every write to it happens
+    /// inside a connection block, which the gate admits one at a time. This test is what enforces
+    /// that invariant: move any command building back outside the gate and it goes red.
+    /// </para>
+    /// </summary>
+    [DataTestMethod]
+    [DynamicData(nameof(JsonSerializers))]
+    [Timeout(60000)]
+    public async Task TychoDb_ConcurrentFilteredReads_ShouldNotCorruptCommands(IJsonSerializer jsonSerializer)
+    {
+        using var db =
+            BuildDatabaseConnection(jsonSerializer)
+                .Connect();
+
+        var testObjs =
+            Enumerable
+                .Range(0, 10)
+                .Select(
+                    i =>
+                        new TestClassA
+                        {
+                            StringProperty = $"Test String {i}",
+                            IntProperty = i,
+                        })
+                .ToList();
+
+        await db.WriteObjectsAsync(testObjs, x => x.StringProperty).ConfigureAwait(false);
+
+        var tasks =
+            Enumerable
+                .Range(0, 8)
+                .Select(
+                    _ =>
+                        Task.Run(
+                            async () =>
+                            {
+                                for (int i = 0; i < 250; i++)
+                                {
+                                    var objs =
+                                        await db
+                                            .ReadObjectsAsync<TestClassA>(
+                                                filter:
+                                                    FilterBuilder<TestClassA>
+                                                        .Create()
+                                                        .Filter(FilterType.Equals, x => x.StringProperty, $"Test String {i % 10}"))
+                                            .ConfigureAwait(false);
+
+                                    objs.Count().ShouldBe(1);
+                                }
+                            }))
+                .ToList();
+
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+    }
+
     public static Tycho BuildDatabaseConnection(IJsonSerializer jsonSerializer, bool requireTypeRegistration = false)
     {
 #if ENCRYPTED

--- a/TychoDB/Tycho.cs
+++ b/TychoDB/Tycho.cs
@@ -48,8 +48,13 @@ public class Tycho : IDisposable
     private readonly int _commandTimeout;
     private readonly Dictionary<Type, RegisteredTypeInformation> _registeredTypeInformation = new();
 
-    // Using a ThreadLocal StringBuilder for better performance with multi-threading
-    private readonly ThreadLocal<StringBuilder> _commandBuilder = new(() => new StringBuilder(1024));
+    // One command builder per database, written to only from inside a connection block. The gate
+    // admits a single operation at a time, so the builder is never touched concurrently, and
+    // capturing it at a call site is a side-effect-free reference read. The previous ThreadLocal
+    // version cleared the builder *at capture time* on the calling thread, which raced with an
+    // in-flight operation still appending to it on a pool thread; every block clears the builder
+    // itself as its first statement, so nothing outside the gate needs to.
+    private readonly StringBuilder _commandBuilder = new(1024);
 
     // RecyclableMemoryStream for efficient memory management - optimized for mobile
     private static readonly RecyclableMemoryStreamManager _memoryStreamManager = new(
@@ -71,16 +76,6 @@ public class Tycho : IDisposable
 
     private SqliteConnection? _connection;
     private bool _isDisposed;
-
-    private StringBuilder ReusableStringBuilder
-    {
-        get
-        {
-            StringBuilder builder = _commandBuilder.Value;
-            builder.Clear();
-            return builder;
-        }
-    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Tycho"/> class.
@@ -523,7 +518,7 @@ public class Tycho : IDisposable
         return _connection
             .WithConnectionBlockAsync(
                 _connectionGate,
-                (partition, filter, withTransaction, commandBuilder: ReusableStringBuilder, _jsonSerializer),
+                (partition, filter, withTransaction, commandBuilder: _commandBuilder, _jsonSerializer),
                 static (conn, state) =>
                 {
                     SqliteTransaction? transaction = null;
@@ -614,7 +609,7 @@ public class Tycho : IDisposable
         return _connection
             .WithConnectionBlockAsync(
                 _connectionGate,
-                (key, partition, withTransaction, commandBuilder: ReusableStringBuilder),
+                (key, partition, withTransaction, commandBuilder: _commandBuilder),
                 static (conn, state) =>
                 {
                     SqliteTransaction? transaction = null;
@@ -700,7 +695,7 @@ public class Tycho : IDisposable
         return _connection
             .WithConnectionBlockAsync(
                 _connectionGate,
-                (key, partition, withTransaction, progress, commandBuilder: ReusableStringBuilder, _jsonSerializer, cancellationToken),
+                (key, partition, withTransaction, progress, commandBuilder: _commandBuilder, _jsonSerializer, cancellationToken),
                 static async (conn, state) =>
                 {
                     SqliteTransaction? transaction = null;
@@ -857,7 +852,7 @@ public class Tycho : IDisposable
         return _connection
             .WithConnectionBlockAsync<IEnumerable<T>, (string? partition, FilterBuilder<T>? filter, SortBuilder<T>? sort, int? top, bool withTransaction, IProgress<double>? progress, StringBuilder commandBuilder, int commandTimeout, IJsonSerializer jsonSerializer, CancellationToken cancellationToken)>(
                 _connectionGate,
-                (partition, filter, sort, top, withTransaction, progress, ReusableStringBuilder, _commandTimeout, _jsonSerializer, cancellationToken),
+                (partition, filter, sort, top, withTransaction, progress, _commandBuilder, _commandTimeout, _jsonSerializer, cancellationToken),
                 static async (conn, state) =>
                 {
                     SqliteTransaction? transaction = null;
@@ -1123,7 +1118,7 @@ public class Tycho : IDisposable
         return _connection
             .WithConnectionBlockAsync<IEnumerable<(string Key, TOut InnerObject)>, (string selectionPath, string? partition, FilterBuilder<TIn>? filter, bool withTransaction, StringBuilder commandBuilder, IJsonSerializer jsonSerializer, CancellationToken cancellationToken)>(
                 _connectionGate,
-                (selectionPath, partition, filter, withTransaction, ReusableStringBuilder, _jsonSerializer, cancellationToken),
+                (selectionPath, partition, filter, withTransaction, _commandBuilder, _jsonSerializer, cancellationToken),
                 static async (conn, state) =>
                 {
                     SqliteTransaction? transaction = null;
@@ -1226,7 +1221,7 @@ public class Tycho : IDisposable
         return _connection
             .WithConnectionBlockAsync(
                 _connectionGate,
-                (key, partition, withTransaction, commandBuilder: ReusableStringBuilder),
+                (key, partition, withTransaction, commandBuilder: _commandBuilder),
                 static (conn, state) =>
                 {
                     SqliteTransaction? transaction = null;
@@ -1293,7 +1288,7 @@ public class Tycho : IDisposable
         return _connection
             .WithConnectionBlockAsync(
                 _connectionGate,
-                (partition, filter, withTransaction, commandBuilder: ReusableStringBuilder, _jsonSerializer),
+                (partition, filter, withTransaction, commandBuilder: _commandBuilder, _jsonSerializer),
                 static (conn, state) =>
                 {
                     SqliteTransaction? transaction = null;
@@ -1359,7 +1354,7 @@ public class Tycho : IDisposable
         return _connection
             .WithConnectionBlockAsync(
                 _connectionGate,
-                (partition, withTransaction, commandBuilder: ReusableStringBuilder),
+                (partition, withTransaction, commandBuilder: _commandBuilder),
                 static (conn, state) =>
                 {
                     SqliteTransaction? transaction = null;
@@ -1415,7 +1410,7 @@ public class Tycho : IDisposable
         return _connection
             .WithConnectionBlockAsync(
                 _connectionGate,
-                (withTransaction, commandBuilder: ReusableStringBuilder),
+                (withTransaction, commandBuilder: _commandBuilder),
                 static (conn, state) =>
                 {
                     SqliteTransaction? transaction = null;
@@ -1540,7 +1535,7 @@ public class Tycho : IDisposable
         return _connection
             .WithConnectionBlockAsync(
                 _connectionGate,
-                (key, partition, commandBuilder: ReusableStringBuilder),
+                (key, partition, commandBuilder: _commandBuilder),
                 static (conn, state) =>
                 {
                     try
@@ -1592,7 +1587,7 @@ public class Tycho : IDisposable
         return _connection
             .WithConnectionBlockAsync(
                 _connectionGate,
-                (key, partition, commandBuilder: ReusableStringBuilder),
+                (key, partition, commandBuilder: _commandBuilder),
                 static (conn, state) =>
                 {
                     try
@@ -1645,7 +1640,7 @@ public class Tycho : IDisposable
         return _connection
             .WithConnectionBlockAsync(
                 _connectionGate,
-                (key, partition, withTransaction, commandBuilder: ReusableStringBuilder),
+                (key, partition, withTransaction, commandBuilder: _commandBuilder),
                 static (conn, state) =>
                 {
                     SqliteTransaction? transaction = null;
@@ -1704,7 +1699,7 @@ public class Tycho : IDisposable
         return _connection
             .WithConnectionBlockAsync(
                 _connectionGate,
-                (partition, withTransaction, commandBuilder: ReusableStringBuilder),
+                (partition, withTransaction, commandBuilder: _commandBuilder),
                 static (conn, state) =>
                 {
                     SqliteTransaction? transaction = null;
@@ -2469,7 +2464,6 @@ public class Tycho : IDisposable
                 RunOptimize(_connection);
             }
 
-            _commandBuilder.Dispose();
             _connectionGate?.Dispose();
             _connection?.Close();
             _connection?.Dispose();


### PR DESCRIPTION
## The bug

Every operation captured its command `StringBuilder` from a `ThreadLocal` on the **calling thread**, then wrote to it after awaiting the connection gate — on a **pool thread**. The `ThreadLocal` keyed the builder per *thread* while the state it holds is per *operation*, so two overlapping operations issued from one thread received the same instance. Worse, the `ReusableStringBuilder` property called `Clear()` **at capture time, outside the gate**, concurrently with an in-flight operation's `Append`.

Three field symptoms, one cause:

- `SqliteException: near "JSON_EXTRACT" / "$fp0" / "AND": syntax error` — SQL truncated mid-build, matching the Sentry signature reported from the field
- **a permanent hang**, spinning at ~119% CPU inside `StringBuilder` on a corrupted chunk chain. It never releases the gate, so every later operation on that database queues behind it forever. No exception, nothing in Sentry
- on 4.4.x, **filtered reads silently returning 0 rows where 1 exists** — data integrity, not a crash

Reproduced deterministically: 3 concurrent tasks × 30 filtered `ReadObjectsAsync` calls goes red 10/10 in ~100ms. One task × 50 reads is green, so concurrency is load-bearing. Also reproduced against tag `v4.4.1`.

## The fix

The *sharing* was never the problem — the side effect at capture time was.

```csharp
private readonly StringBuilder _commandBuilder = new(1024);
```

One builder per database, captured by a side-effect-free reference read, cleared by each block as its first statement (which every block already did).

This is safe because of three things I verified rather than assumed:

1. A gate-concurrency probe confirmed the `SemaphoreSlim` admits **exactly one** operation at a time — max simultaneous holders was 1 even while the SQL was being corrupted, which is what ruled out "the gate is broken" as the cause.
2. All 28 builder mutation sites (plus `FilterBuilder.Build` / `SortBuilder.Build`) are inside connection blocks.
3. Nothing escapes the gate holding the builder — results materialize into a `List<T>` before return, and there is no `yield return` anywhere in `Tycho.cs`.

## Cost

Measured over 5000 filtered reads, single-threaded:

| approach | alloc/read | time/read |
|---|---|---|
| broken `ThreadLocal` | 4786 B | 69.1–69.3 µs |
| **this change** | **4786 B (+0)** | 67.9–71.3 µs |
| `new StringBuilder(1024)` per operation | 6906 B (+2120) | 68.0–72.3 µs |

A fresh builder per operation also fixes the race, but costs 2120 B of gen0 per read — `new StringBuilder(1024)` reserves 1024 *chars*, not bytes.

## Test

`TychoDb_ConcurrentFilteredReads_ShouldNotCorruptCommands` — 8 tasks × 250 filtered reads, both serializers. Red in <100ms against the previous implementation, green here. Full suite: 182 passed.

The `[Timeout]` is load-bearing: the original defect **hangs** rather than throws, so without it a regression wedges CI instead of failing it.

The test also pins the invariant this fix now depends on — move any command building back outside the gate and it goes red.

## Trade-off

The builder is retained for the instance lifetime at its high-water-mark capacity, so a one-off query with a huge `IN`-list would leave that buffer resident where a per-operation builder would be collected. Trivial to bound later (reset capacity in the block above a threshold); left out as premature.

## Notes

- Supersedes `feature/per-operation-command-builder`, which carried the per-operation-allocation variant against a stale `develop` base.
- `release/4.4.2` deliberately keeps the per-operation allocation — its sync paths call `rateLimiter.AttemptAcquire()` without checking the lease, so a patch release for users already in production shouldn't rest on a gate invariant that branch only partially upholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)